### PR TITLE
Implement unsize crate's trait CoerciblePtr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ traits = ["stable_deref_trait", "aliasable_deref_trait"]
 [dependencies]
 stable_deref_trait = { version = "1.2", optional = true }
 aliasable_deref_trait = { version = "0.2", optional = true }
+unsize = { version = "1.1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This provides a patch to unsizing some of the pointers of this crate.
This is usually an implicit operation but opt-in to those is gated on an
unstable trait. The unsize crate provides an alternative that is
explicit yet remains safe for the caller.