### PR TITLE
Implement derivable traits

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -211,6 +211,7 @@ unsafe impl<T, U: ?Sized> unsize::CoerciblePtr<U> for AliasableBox<T> {
 #[cfg(test)]
 mod tests {
     use super::{AliasableBox, UniqueBox};
+    use crate::test_utils::{check_ordering, hash_of};
     use alloc::format;
 
     #[test]
@@ -243,6 +244,34 @@ mod tests {
     fn test_debug() {
         let aliasable = AliasableBox::from_unique(UniqueBox::new(10));
         assert_eq!(format!("{:?}", aliasable), "10");
+    }
+
+    #[test]
+    fn test_default() {
+        assert_eq!(*<AliasableBox<i32>>::default(), 0);
+    }
+
+    #[test]
+    #[allow(clippy::redundant_clone)]
+    fn test_clone() {
+        let mut boxed = AliasableBox::from_unique(UniqueBox::new(10));
+        assert_eq!(*boxed.clone(), 10);
+        boxed.clone_from(&AliasableBox::from_unique(UniqueBox::new(20)));
+        assert_eq!(*boxed, 20);
+    }
+
+    #[test]
+    fn test_cmp() {
+        check_ordering(
+            AliasableBox::from_unique(UniqueBox::new(5)),
+            AliasableBox::from_unique(UniqueBox::new(7)),
+        );
+    }
+
+    #[test]
+    fn test_hash() {
+        let b = UniqueBox::new(5);
+        assert_eq!(hash_of(AliasableBox::from_unique(b.clone())), hash_of(b));
     }
 
     #[cfg(feature = "unsize")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,3 +58,66 @@ pub mod prelude {
 pub use aliasable_deref_trait::AliasableDeref;
 #[cfg(feature = "stable_deref_trait")]
 pub use stable_deref_trait::StableDeref;
+
+#[cfg(test)]
+mod test_utils {
+    use alloc::vec::Vec;
+    use core::cmp::Ordering;
+    use core::fmt::Debug;
+    use core::hash::{Hash, Hasher};
+
+    #[allow(clippy::eq_op)]
+    pub(crate) fn check_ordering<T: PartialEq + Eq + PartialOrd + Ord + Debug>(a: T, b: T) {
+        assert_eq!(a, a);
+        assert_eq!(b, b);
+        assert_ne!(a, b);
+        assert_ne!(b, a);
+
+        assert_eq!(a.cmp(&a), Ordering::Equal);
+        assert_eq!(b.cmp(&b), Ordering::Equal);
+        assert_eq!(a.cmp(&b), Ordering::Less);
+        assert_eq!(b.cmp(&a), Ordering::Greater);
+
+        assert_eq!(a.partial_cmp(&a).unwrap(), Ordering::Equal);
+        assert_eq!(b.partial_cmp(&b).unwrap(), Ordering::Equal);
+        assert_eq!(a.partial_cmp(&b).unwrap(), Ordering::Less);
+        assert_eq!(b.partial_cmp(&a).unwrap(), Ordering::Greater);
+
+        assert!(!(a < a));
+        assert!(!(b < b));
+        assert!(a < b);
+        assert!(!(b < a));
+
+        assert!(!(a > a));
+        assert!(!(b > b));
+        assert!(!(a > b));
+        assert!(b > a);
+
+        assert!(a <= a);
+        assert!(b <= b);
+        assert!(a <= b);
+        assert!(!(b <= a));
+
+        assert!(a >= a);
+        assert!(b >= b);
+        assert!(!(a >= b));
+        assert!(b >= a);
+    }
+
+    pub(crate) fn hash_of(value: impl Hash) -> Vec<u8> {
+        #[derive(Default, PartialEq)]
+        struct DummyHasher(Vec<u8>);
+        impl Hasher for DummyHasher {
+            fn finish(&self) -> u64 {
+                0
+            }
+            fn write(&mut self, bytes: &[u8]) {
+                self.0.extend_from_slice(bytes);
+            }
+        }
+
+        let mut hasher = DummyHasher::default();
+        value.hash(&mut hasher);
+        hasher.0
+    }
+}

--- a/src/mut_ref.rs
+++ b/src/mut_ref.rs
@@ -1,6 +1,8 @@
 //! Aliasable `&mut`.
 
+use core::cmp::Ordering;
 use core::fmt;
+use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
@@ -112,6 +114,51 @@ where
 
 unsafe impl<T: ?Sized> Send for AliasableMut<'_, T> where T: Send {}
 unsafe impl<T: ?Sized> Sync for AliasableMut<'_, T> where T: Sync {}
+
+impl<T: PartialEq + ?Sized> PartialEq for AliasableMut<'_, T> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl<T: Eq + ?Sized> Eq for AliasableMut<'_, T> {}
+
+impl<T: PartialOrd + ?Sized> PartialOrd for AliasableMut<'_, T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (**self).partial_cmp(&**other)
+    }
+    #[inline]
+    fn lt(&self, other: &Self) -> bool {
+        **self < **other
+    }
+    #[inline]
+    fn le(&self, other: &Self) -> bool {
+        **self <= **other
+    }
+    #[inline]
+    fn gt(&self, other: &Self) -> bool {
+        **self > **other
+    }
+    #[inline]
+    fn ge(&self, other: &Self) -> bool {
+        **self >= **other
+    }
+}
+
+impl<T: Ord + ?Sized> Ord for AliasableMut<'_, T> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        (**self).cmp(&**other)
+    }
+}
+
+impl<T: Hash + ?Sized> Hash for AliasableMut<'_, T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (**self).hash(state);
+    }
+}
 
 #[cfg(feature = "stable_deref_trait")]
 unsafe impl<T: ?Sized> crate::StableDeref for AliasableMut<'_, T> {}

--- a/src/mut_ref.rs
+++ b/src/mut_ref.rs
@@ -169,6 +169,7 @@ unsafe impl<T: ?Sized> crate::AliasableDeref for AliasableMut<'_, T> {}
 #[cfg(test)]
 mod tests {
     use super::AliasableMut;
+    use crate::test_utils::{check_ordering, hash_of};
     use alloc::boxed::Box;
     use alloc::format;
     use core::pin::Pin;
@@ -208,5 +209,18 @@ mod tests {
         let mut data = 10;
         let aliasable = AliasableMut::from_unique(&mut data);
         assert_eq!(format!("{:?}", aliasable), "10");
+    }
+
+    #[test]
+    fn test_cmp() {
+        check_ordering(
+            AliasableMut::from_unique(&mut 5),
+            AliasableMut::from_unique(&mut 7),
+        );
+    }
+
+    #[test]
+    fn test_hash() {
+        assert_eq!(hash_of(AliasableMut::from_unique(&mut 389)), hash_of(389));
     }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -141,6 +141,7 @@ unsafe impl crate::AliasableDeref for AliasableString {}
 #[cfg(test)]
 mod tests {
     use super::{AliasableString, AliasableVec, UniqueString};
+    use crate::test_utils::{check_ordering, hash_of};
     use alloc::{format, vec};
     use core::pin::Pin;
 
@@ -182,6 +183,39 @@ mod tests {
         assert_eq!(
             AliasableVec::into_unique(aliasable.into_bytes()),
             vec![b'h', b'e', b'l', b'l', b'o']
+        );
+    }
+
+    #[test]
+    fn test_default() {
+        assert_eq!(
+            AliasableString::default(),
+            AliasableString::from_unique(UniqueString::new())
+        );
+    }
+
+    #[test]
+    #[allow(clippy::redundant_clone)]
+    fn test_clone() {
+        let mut s = AliasableString::from_unique("hello".into());
+        assert_eq!(&*s.clone(), "hello");
+        s.clone_from(&AliasableString::from_unique("world".into()));
+        assert_eq!(&*s, "world");
+    }
+
+    #[test]
+    fn test_cmp() {
+        check_ordering(
+            AliasableString::from_unique("abcdef".into()),
+            AliasableString::from_unique("abdef".into()),
+        );
+    }
+
+    #[test]
+    fn test_hash() {
+        assert_eq!(
+            hash_of(AliasableString::from_unique("some data".into())),
+            hash_of("some data")
         );
     }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,5 +1,6 @@
 //! Aliasable `String`.
 
+use core::hash::{Hash, Hasher};
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::{fmt, str};
@@ -10,6 +11,7 @@ pub use alloc::string::String as UniqueString;
 
 /// Basic aliasable (non `core::ptr::Unique`) alternative to
 /// [`alloc::string::String`].
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct AliasableString(AliasableVec<u8>);
 
 impl AliasableString {
@@ -100,6 +102,33 @@ impl AsMut<str> for AliasableString {
 impl fmt::Debug for AliasableString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_ref(), f)
+    }
+}
+
+impl Default for AliasableString {
+    #[inline]
+    fn default() -> Self {
+        Self::from_unique(UniqueString::default())
+    }
+}
+
+impl Clone for AliasableString {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        self.0.clone_from(&source.0);
+    }
+}
+
+// Deriving `Hash` would be incorrect because it would hash as bytes and not a string.
+#[allow(clippy::derive_hash_xor_eq)]
+impl Hash for AliasableString {
+    #[inline]
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        (**self).hash(hasher);
     }
 }
 


### PR DESCRIPTION
By implementing just the derivable traits on the `Aliasable*` types, users can easily derive traits on containers. This is especially useful for types created by Ouroboros, to allow this to compile: 

```rust
#[derive(PartialEq)]
#[self_referencing]
struct SelfRef {
    x: i32,
    #[borrows(x)]
    y: &'this i32,
}
```