### PR TITLE
Added capacity to AliasableString

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -15,6 +15,11 @@ pub use alloc::string::String as UniqueString;
 pub struct AliasableString(AliasableVec<u8>);
 
 impl AliasableString {
+    /// Returns the number of bytes the string can hold without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
     /// Consumes `self` into an [`AliasableVec`] of UTF-8 bytes.
     pub fn into_bytes(self) -> AliasableVec<u8> {
         self.0


### PR DESCRIPTION
This (very simple) PR adds `capacity` to `AliasableString`.

It would be really nice if you could make a minor release with the current repo version—we really need capacity information to implement correctly [`MemSize`](https://crates.io/crates/mem_dbg) for the types in this repo...